### PR TITLE
fix: Wrong title on navbar

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -3,7 +3,7 @@ import Link from "next/link"
 const Navbar = () => {
   return (
     <nav className="flex justify-between bg-[#0A2647] p-4 py-6 text-white">
-      <h3 className="font-bold">Questup</h3>
+      <h3 className="font-bold">Quizaction</h3>
       <div>
         <ul className="flex gap-4">
           <li>


### PR DESCRIPTION
![resim](https://user-images.githubusercontent.com/61623638/222925579-e57f886e-7e52-4c47-9551-b5e604ab09e6.png)

`Questup` changed to `Quizaction`